### PR TITLE
Se agrega SignIn y se actuliza SignUp - Java

### DIFF
--- a/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
+++ b/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
@@ -8,27 +8,37 @@ import co.com.bancolombia.model.user.gateways.UserRepository;
 import co.com.bancolombia.model.session.gateways.SessionRepository;
 import co.com.bancolombia.model.exception.DomainError;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 @RequiredArgsConstructor
 public class SignInUseCase {
+    private static final Logger log = LoggerFactory.getLogger(SignInUseCase.class);
     private final UserRepository userRepository;
     private final SessionRepository sessionRepository;
 
     public Mono<Session> execute(User user, ContextData context) {
+        log.debug("Iniciando SignIn para email={}, context={}", user != null ? user.getEmail() : null, context);
         if (user == null || user.getEmail() == null || user.getPassword() == null) {
+            log.warn("Request mal formado: {}", user);
             return Mono.error(new DomainError("MALFORMED_REQUEST", "Request inválido", null, context));
         }
         return userRepository.findByEmail(user.getEmail())
-                .switchIfEmpty(Mono.error(new DomainError("USER_NOT_FOUND", "Usuario no existe", null, context)))
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("Usuario no encontrado: {}", user.getEmail());
+                    return Mono.error(new DomainError("USER_NOT_FOUND", "Usuario no existe", null, context));
+                }))
                 .flatMap(u -> {
                     if (!u.getPassword().equals(user.getPassword())) {
+                        log.warn("Credenciales inválidas para email={}", user.getEmail());
                         return Mono.error(new DomainError("INVALID_CREDENTIALS", "Credenciales inválidas", null, context));
                     }
                     String sessionId = UUID.randomUUID().toString();
                     Session session = new Session(sessionId, user.getEmail());
+                    log.info("Signin exitoso email={}, sessionId={}", user.getEmail(), sessionId);
                     return sessionRepository.save(session).thenReturn(session);
                 });
     }

--- a/ms-auth-java/infrastructure/driven-adapters/memory-persistence/src/main/java/co/com/bancolombia/memorypersistence/useradapter/UserAdapterImpl.java
+++ b/ms-auth-java/infrastructure/driven-adapters/memory-persistence/src/main/java/co/com/bancolombia/memorypersistence/useradapter/UserAdapterImpl.java
@@ -2,6 +2,8 @@ package co.com.bancolombia.memorypersistence.useradapter;
 
 import co.com.bancolombia.model.user.User;
 import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
@@ -9,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class UserAdapterImpl implements UserRepository {
+    private static final Log log = LogFactory.getLog(UserAdapterImpl.class);
     private final ConcurrentHashMap<String, String> users = new ConcurrentHashMap<>();
 
     @Override
@@ -23,6 +26,7 @@ public class UserAdapterImpl implements UserRepository {
     @Override
     public Mono<Void> save(User user) {
         users.put(user.getEmail(), user.getPassword());
+        log.info("User saved: " + user.getEmail());
         return Mono.empty();
     }
 }

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
@@ -7,9 +7,11 @@ import co.com.bancolombia.usecase.signin.SignInUseCase;
 import co.com.bancolombia.usecase.signup.SignUpUseCase;
 import co.com.bancolombia.util.request.SignInRequest;
 import co.com.bancolombia.util.request.SignUpRequest;
+import co.com.bancolombia.util.response.SignInResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -60,10 +62,14 @@ public class Handler {
                             return signInUseCase.execute(user, context);
                         })
                 )
-                .then(ServerResponse.ok()
-                        .header("message-id", serverRequest.headers().firstHeader("message-id"))
-                        .header("consumer-code", serverRequest.headers().firstHeader("consumer-code"))
-                        .build());
+                .flatMap(session -> {
+                    SignInResponse body = new SignInResponse(session.getSessionId());
+                    return ServerResponse.ok()
+                            .header("message-id", serverRequest.headers().firstHeader("message-id"))
+                            .header("consumer-code", serverRequest.headers().firstHeader("consumer-code"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(body);
+                });
     }
 
 

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
@@ -40,24 +40,32 @@ public class Handler {
                             return signUpUseCase.execute(user, contextData);
                         })
                 )
-                .flatMap(result -> {
-                    log.info("Signup exitoso para usuario: {}", result);
-                    return ServerResponse.ok().bodyValue(result);
-                });
+                .then(ServerResponse.created(serverRequest.uri())
+                        .header("message-id", serverRequest.headers().firstHeader("message-id"))
+                        .header("consumer-code", serverRequest.headers().firstHeader("consumer-code"))
+                        .build());
     }
 
-    /*
+
     public Mono<ServerResponse> signinPOSTUseCase(ServerRequest serverRequest) {
+        log.debug("Iniciando proceso de signin");
         return headersValidation.validateHeaders(serverRequest)
-                .flatMap(user -> serverRequest.bodyToMono(SignInRequest.class)
+                .then(serverRequest.bodyToMono(SignInRequest.class)
                         .flatMap(request -> {
-                            String messageId = serverRequest.headers().firstHeader("message-id-header");
-                            return signInUseCase.execute(user, messageId);
+                            User user = mapToUserSignInRequest(request);
+                            ContextData context = ContextData.builder()
+                                    .messageId(serverRequest.headers().firstHeader("message-id"))
+                                    .consumerCode(serverRequest.headers().firstHeader("consumer-code"))
+                                    .build();
+                            return signInUseCase.execute(user, context);
                         })
                 )
-                .flatMap(result -> ServerResponse.ok().bodyValue(result));
+                .then(ServerResponse.ok()
+                        .header("message-id", serverRequest.headers().firstHeader("message-id"))
+                        .header("consumer-code", serverRequest.headers().firstHeader("consumer-code"))
+                        .build());
     }
-    */
+
 
     private User mapToUserSignUpRequest(SignUpRequest request) {
 
@@ -66,10 +74,10 @@ public class Handler {
                 password(request.getPassword()).
                 build();
     }
-   /* private User mapToUserSignInRequest(SignInRequest request) {
+    private User mapToUserSignInRequest(SignInRequest request) {
         return User.builder().
                 email(request.getEmail()).
                 password(request.getPassword()).
                 build();
-    }*/
+    }
 }

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java
@@ -31,7 +31,7 @@ public class Handler {
         return headersValidation.validateHeaders(serverRequest)
                 .then(serverRequest.bodyToMono(SignUpRequest.class)
                         .flatMap(request -> {
-                            log.info("Datos recibidos para signup: {}", request);
+                            log.info("Datos recibidos para signup: {}", request.getEmail());
                             User user = mapToUserSignUpRequest(request);
                             String messageId = serverRequest.headers().firstHeader("message-id");
                             String consumerCode = serverRequest.headers().firstHeader("consumer-code");

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java
@@ -13,7 +13,7 @@ public class RouterRest {
     @Bean
     public RouterFunction<ServerResponse> routerFunction(Handler handler) {
         return route(POST("/api/v1/signup"), handler::signupPOSTUseCase)
-                //.andRoute(POST("/api/v1/signin"), handler::signinPOSTUseCase)
+                .andRoute(POST("/api/v1/signin"), handler::signinPOSTUseCase)
                 ;
     }
 }

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/util/response/SignInResponse.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/util/response/SignInResponse.java
@@ -1,0 +1,11 @@
+package co.com.bancolombia.util.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SignInResponse {
+    private String sessionId;
+}

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/RouterRestTest.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/RouterRestTest.java
@@ -46,24 +46,27 @@ class RouterRestTest {
                 .header("consumer-code", "test-consumer")
                 .bodyValue("{\"name\":\"Test\",\"email\":\"test@test.com\",\"password\":\"1234\"}")
                 .exchange()
-                .expectStatus().isOk()
-                .expectBody(String.class)
-                .value(userResponse -> Assertions.assertThat(userResponse).isEmpty());
+                .expectStatus().isCreated()
+                .expectBody().isEmpty();
+
     }
 
-
-  /*
     @Test
     void signinPOSTUseCase() {
+        when(headersValidation.validateHeaders(ArgumentMatchers.any()))
+                .thenReturn(Mono.empty());
+        when(signInUseCase.execute(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(Mono.empty());
+
         webTestClient.post()
                 .uri("/api/v1/signin")
+                .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("message-id", "123e4567-e89b-12d3-a456-426614174000")
                 .header("consumer-code", "test-consumer")
-                .bodyValue("{\"username\":\"Test\",\"password\":\"1234\"}")
+                .bodyValue("{\"email\":\"test@test.com\",\"password\":\"12345678\"}")
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(String.class)
-                .value(userResponse -> Assertions.assertThat(userResponse).isEmpty());
-    }*/
+                .expectBody().isEmpty();
+    }
 }


### PR DESCRIPTION
This pull request introduces improved logging, refactors the sign-in/sign-up API endpoints, and adds a response model for sign-in, enhancing both traceability and API response structure. It also enables the `/api/v1/signin` endpoint and updates related tests for correctness and coverage.

### Logging enhancements

* Added detailed logging at various points in the `SignInUseCase` to trace sign-in attempts, malformed requests, user not found, invalid credentials, and successful sign-ins.
* Added logging in `UserAdapterImpl` to log when a user is saved in memory. [[1]](diffhunk://#diff-e8bc8381a80542f6f93826ea4944cc7f1dc60fb32a5cdbd2e013c8982d4f9c1fR5-R14) [[2]](diffhunk://#diff-e8bc8381a80542f6f93826ea4944cc7f1dc60fb32a5cdbd2e013c8982d4f9c1fR29)

### API endpoint improvements

* Refactored the sign-up endpoint to log only the user's email (not the full request), and changed the response to return HTTP 201 Created with headers, rather than returning the user object. [[1]](diffhunk://#diff-55ece131e8986fd7634de030e9cbdfc05e9535f244c55af9d03987e66b392c2fL32-R34) [[2]](diffhunk://#diff-55ece131e8986fd7634de030e9cbdfc05e9535f244c55af9d03987e66b392c2fL43-R74)
* Refactored the sign-in endpoint to use a new `SignInResponse` model, return session information in JSON, and include headers in the response. Also improved request mapping and context construction. [[1]](diffhunk://#diff-55ece131e8986fd7634de030e9cbdfc05e9535f244c55af9d03987e66b392c2fL43-R74) [[2]](diffhunk://#diff-55ece131e8986fd7634de030e9cbdfc05e9535f244c55af9d03987e66b392c2fL69-R88) [[3]](diffhunk://#diff-68ac08d33ed6d0f653d0a4de8748cbd82a3ee06215e7f90c29220034136088baR1-R11)

### Router and test updates

* Enabled the `/api/v1/signin` route in the router configuration, making the endpoint available.
* Updated tests to reflect the new response codes and body expectations for both sign-up and sign-in endpoints.