### PR TITLE
Se actualiza micros

### DIFF
--- a/ms-auth-elixir/lib/domain/behaviours/sign_in_behaviour.ex
+++ b/ms-auth-elixir/lib/domain/behaviours/sign_in_behaviour.ex
@@ -1,0 +1,7 @@
+defmodule Authelixir.Domain.Behaviours.SignInBehaviour do
+  @moduledoc """
+  SignInBehaviour
+  """
+
+  # @callback replace_function_name(param_one::term, param_two::term)::{:ok, true::term} | {:error, reason::term}
+end

--- a/ms-auth-elixir/lib/domain/behaviours/sign_up_behaviour.ex
+++ b/ms-auth-elixir/lib/domain/behaviours/sign_up_behaviour.ex
@@ -1,0 +1,7 @@
+defmodule Authelixir.Domain.Behaviours.SignUpBehaviour do
+  @moduledoc """
+  SignUpBehaviour
+  """
+
+  # @callback replace_function_name(param_one::term, param_two::term)::{:ok, true::term} | {:error, reason::term}
+end

--- a/ms-auth-elixir/lib/domain/model/sign_in.ex
+++ b/ms-auth-elixir/lib/domain/model/sign_in.ex
@@ -1,0 +1,11 @@
+defmodule Authelixir.Domain.Model.SignIn do
+  @moduledoc """
+  SignIn
+  """
+
+  defstruct []
+
+  def new() do
+    %__MODULE__{}
+  end
+end

--- a/ms-auth-elixir/lib/domain/model/sign_up.ex
+++ b/ms-auth-elixir/lib/domain/model/sign_up.ex
@@ -1,0 +1,11 @@
+defmodule Authelixir.Domain.Model.SignUp do
+  @moduledoc """
+  SignUp
+  """
+
+  defstruct []
+
+  def new() do
+    %__MODULE__{}
+  end
+end

--- a/ms-auth-elixir/lib/infrastructure/entry_points/api_rest.ex
+++ b/ms-auth-elixir/lib/infrastructure/entry_points/api_rest.ex
@@ -21,7 +21,7 @@ defmodule Authelixir.Infrastructure.EntryPoint.ApiRest do
   plug(:dispatch)
 
   forward(
-    "/api/health",
+    "/api/v1/health",
     to: PlugCheckup,
     init_opts:
       PlugCheckup.Options.new(
@@ -30,7 +30,7 @@ defmodule Authelixir.Infrastructure.EntryPoint.ApiRest do
       )
   )
 
-  get "/api/hello" do
+  get "/api/v1/hello" do
     build_response("Hello World", conn)
   end
 

--- a/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/signin/SignIn.java
+++ b/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/signin/SignIn.java
@@ -4,12 +4,10 @@ import co.com.bancolombia.model.user.User;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-//import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-//@NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class SignIn {

--- a/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/signup/SignUp.java
+++ b/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/signup/SignUp.java
@@ -3,12 +3,10 @@ import co.com.bancolombia.model.user.User;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-//import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-//@NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class SignUp {

--- a/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
+++ b/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
@@ -1,8 +1,6 @@
-// src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
 package co.com.bancolombia.usecase.signin;
 
 import co.com.bancolombia.model.signin.gateways.SignInRepository;
-import co.com.bancolombia.model.signup.gateways.SignUpRepository;
 import co.com.bancolombia.model.user.User;
 import co.com.bancolombia.model.session.Session;
 import co.com.bancolombia.model.contextdata.ContextData;

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/CorsConfig.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         config.setAllowedOrigins(List.of(origins.split(",")));
-        config.setAllowedMethods(Arrays.asList("POST", "GET")); // TODO: Check others required methods
+        config.setAllowedMethods(Arrays.asList("POST", "GET"));
         config.setAllowedHeaders(List.of(CorsConfiguration.ALL));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/util/request/SignInRequest.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/util/request/SignInRequest.java
@@ -7,7 +7,6 @@ public class SignInRequest {
     private String email;
     private String password;
 
-    // Getters y setters
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
 

--- a/ms-auth-java/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/RouterRestTest.java
+++ b/ms-auth-java/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/RouterRestTest.java
@@ -40,7 +40,7 @@ class RouterRestTest {
 
         webTestClient.post()
                 .uri("/api/v1/signup")
-                .contentType(MediaType.APPLICATION_JSON) // <- Agrega esta línea
+                .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("message-id", "123e4567-e89b-12d3-a456-426614174000")
                 .header("x-request-id", "x-request-id-test")


### PR DESCRIPTION
This pull request introduces foundational domain models and behaviours for sign-in and sign-up functionality in Elixir, and makes minor improvements and cleanups in the Java codebase. It also updates API endpoint routes to use versioning for better maintainability. The most important changes are grouped below.

**Elixir Domain Layer Additions:**

* Added new behaviour modules: `SignInBehaviour` and `SignUpBehaviour` in `lib/domain/behaviours`, laying groundwork for sign-in and sign-up abstractions. [[1]](diffhunk://#diff-c744405b3d1ec4997d155c756b2575318829abd7104979b37be09fddf28b0b4eR1-R7) [[2]](diffhunk://#diff-5a7b503744496a7c4689e287ba5ef39d48e9b952e19a50956e1d42ff6ea655a8R1-R7)
* Created domain model modules: `SignIn` and `SignUp` in `lib/domain/model`, each with a `new/0` constructor for instance creation. [[1]](diffhunk://#diff-fadeec36864e8fc59bb899c85dab7045f27a79e94a906d4c6ce84495fc0ba665R1-R11) [[2]](diffhunk://#diff-4c13b37d0362d61467df7ce5d42be8a7cbd74b7f69f4d0f61668d611d7b86604R1-R11)

**API Endpoint Versioning:**

* Updated health and hello endpoints in `api_rest.ex` to use `/api/v1/` prefix, introducing API versioning for future compatibility. [[1]](diffhunk://#diff-f54f5f784c7bb289e26eedc5380adff7b2606f358e861d61225467e647aa41c5L24-R24) [[2]](diffhunk://#diff-f54f5f784c7bb289e26eedc5380adff7b2606f358e861d61225467e647aa41c5L33-R33)

**Java Codebase Cleanups:**

* Removed commented-out `NoArgsConstructor` annotations from `SignIn.java` and `SignUp.java` for cleaner model definitions. [[1]](diffhunk://#diff-6b5ba4d9c4c842c50c8f9823d506f55d55316074e6765a776c4014ae82636b13L7-L12) [[2]](diffhunk://#diff-ccec7e4d617317723857a8fbd6b809a22e91e23e625a7b207dd02184b79e1ad9L6-L11)
* Removed an unused import (`SignUpRepository`) from `SignInUseCase.java`.
* Minor code comment and formatting cleanups, such as removing a redundant comment in `SignInRequest.java` and a TODO in CORS config. [[1]](diffhunk://#diff-cda201a47ff518813a16dc51c8cbf3912b15c1d70744e7075fe86abfb638188dL10) [[2]](diffhunk://#diff-50c181d9872f55588f880153abbf8f7504b5f925bd5d754f1348de06b0593a0eL21-R21)
* Updated a test in `RouterRestTest.java` to clean up a comment on content type specification.