### PR TITLE
Refactorizar el manejo de errores en los casos de uso de SignIn y SignUp

### DIFF
--- a/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/exception/model/CodeMessage.java
+++ b/ms-auth-java/domain/model/src/main/java/co/com/bancolombia/model/exception/model/CodeMessage.java
@@ -1,57 +1,20 @@
 package co.com.bancolombia.model.exception.model;
 
 public class CodeMessage {
-    public static final String INVALID_HEADER_DETAIL = "Faltan cabeceras obligatorias";
-    public static final String MISSING_PARAMS_BODY = "Faltan parámetros obligatorios.";
-    public static final String SUID_CONSUMER_DETAIL = "El consumidor no se encuentra registrado";
-    public static final String INVALID_DATA_DETAIL = "Uno o más datos no poseen un valor válido.";
-    public static final String EMPTY_SEARCH_IDENTITY_DETAIL = "Registro no encontrado";
-    public static final String MAXIM_DELEGATES_NUMBER_DETAIL = "Supera el número máximo permitido de delegados";
-    public static final String SCHEME_INVALID_DETAIL = "Control no válido";
-    public static final String SCHEME_ALREADY_ASSIGN_DETAIL = "Cliente ya tiene un esquema asociado";
-    public static final String EXPIRATION_DAY_MAXIMUM_DETAIL = "Cantidad de días no válido";
-    public static final String EXTERNAL_FAIL_DETAIL = "Error en la llamanda a un servicio externo";
-    public static final String UNKNOWN_ERROR_PERMISSION_DETAIL =
-            "Ha ocurrido un error interno en el servicio transversal de permisos";
-    public static final String UNKNOWN_ERROR_ROLLBACK_SERVICE = "Ha ocurrido un error interno en el servicio";
-    public static final String UNKNOWN_ERROR_PARAM_DETAIL = "Ha ocurrido un error interno en el servicio";
-    public static final String UNKNOWN_ERROR_DETAIL = "Ha ocurrido un error interno en el servicio";
-    public static final String CLIENT_NOT_EXIST_DETAIL = "Consulta no retorna resultado";
-    public static final String NOT_PRIVILEGES_DETAIL = "No cuenta con los permisos para ejecutar la acción";
-    public static final String USER_WITH_RELATIONSHIP_DETAIL = "Usuario con relación existente";
-    public static final String RELATIONSHIP_NOT_FOUND_DETAIL = "No se encuentran registros de relacionamiento";
-    public static final String REGISTER_EXIST_DETAIL = "No es posible crear la relación";
-    public static final String USER_NOT_EXIST_DETAIL = "No existe registro para la consulta";
-    public static final String USER_NOT_FOUND_DETAIL = "El AID no corresponde a la identidad ingresada";
-    public static final String STATUS_ALIAS_DISABLE_DETAIL = "El estado del alias no se encuentra activo";
-    public static final String ROL_NOT_EXIST_DETAIL = "El role no existe";
-    public static final String UPDATE_IN_PROCESS_DETAIL = "Existe una actualizacion en proceso";
-    public static final String DEFAULT_MESSAGE = "Ha ocurrido un error interno en el servicio.";
-    public static final String STATUS_DIFFERENT_PENDING_DETAIL = "El estado de relación es diferente a PENDIENTE";
-    public static final String EXCEEDED_NUMBER_OF_RETRIES_DETAIL = "Superaste el número de intentos permitidos";
-    public static final String UNAUTHORIZED_CONSUMER_DETAIL = "Consumidor no autorizado";
-    public static final String USER_WITHOUT_DELEGATES_DETAIL = "Usuario no cuenta con delegaciones";
-    public static final String PAGE_WITHOUT_RECORDS_DETAIL = "Pagina no cuenta con registros";
-    public static final String UNPROCESSED_MESSAGE_DETAIL = "No fue posible procesar la transacción";
-    public static final String NO_ACTIVE_ROL_CODE_DETAIL = "Role no se encuentra en estado ACTIVO";
-    public static final String SCHEMA_FULL_DETAIL = "Cantidad titulares supera control elegido";
-    public static final String SELF_MANAGEMENT_UPDATE_ROL_DETAIL = "No se permite la autogestión de cambio de role";
-    public static final String PENDING_RELATIONSHIP_DETAIL = "Relación en estado PENDIENTE";
-    public static final String DELEGATE_WITH_ROLE_DETAIL = "El delegado ya cuenta con el rol a asignar";
-    public static final String TITULAR_ROLE_CODE_DETAIL = "El Role pertenece a un TITULAR";
-    public static final String ROLE_INVALID_DETAIL = "Dominio de valores asociado al rol es inválido";
-    public static final String OTP_CODE_NOT_VALID_DETAIL = "Código de afiliación no válido";
-    public static final String CLIENT_WITHOUT_SCHEMA_DETAIL = "El cliente no tiene un control asociado";
-    public static final String TITULAR_NOT_FOUND_DETAIL = "No se encontraron titulares";
-    public static final String STATUS_NOT_MODIFY_RELATIONSHIP_DETAIL =
-            "El estado actual de la relación no se puede modificar";
-    public static final String REGISTER_WITHOUT_REP_DETAIL = "No se ha registrado el representante legal";
-    public static final String TRANSACTION_IN_PROCESS_DETAIL = "Ya existe una transacción en proceso";
-    public static final String TRANSACTION_AVAILABILITY_DETAIL =
-            "Ha ocurrido un error interno en el servicio de transacciones";
-    public static final String OTP_CODE_VALIDATED_DETAIL = "Código de afiliación ya se validó";
-    public static final String OTP_CODE_EXPIRED_DETAIL = "Código de afiliación expirado";
-    public static final String UNAUTHORIZED = "Cliente no autorizado";
+
+    public static final String MALFORMED_REQUEST_CODE = "MALFORMED_REQUEST";
+    public static final String USER_NOT_FOUND_CODE = "USER_NOT_FOUND";
+    public static final String INVALID_CREDENTIALS_CODE = "INVALID_CREDENTIALS";
+    public static final String REQUEST_INVALID_MESSAGE = "Request inválido";
+    public static final String USER_NOT_EXISTS_MESSAGE = "Usuario no existe";
+    public static final String INVALID_CREDENTIALS_MESSAGE = "Credenciales inválidas";
+    public static final String INVALID_EMAIL_FORMAT_CODE = "INVALID_EMAIL_FORMAT";
+    public static final String WEAK_PASSWORD_CODE = "WEAK_PASSWORD";
+    public static final String EMAIL_ALREADY_EXISTS_CODE = "EMAIL_ALREADY_EXISTS";
+    public static final String INVALID_EMAIL_FORMAT_MESSAGE = "Email inválido";
+    public static final String WEAK_PASSWORD_MESSAGE = "Password débil";
+    public static final String EMAIL_ALREADY_EXISTS_MESSAGE = "Email ya registrado";
+
 
     private CodeMessage() {
         throw new IllegalStateException("CodeMessage class");

--- a/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
+++ b/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signin/SignInUseCase.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.usecase.signin;
 
+import co.com.bancolombia.model.exception.model.CodeMessage;
 import co.com.bancolombia.model.signin.gateways.SignInRepository;
 import co.com.bancolombia.model.user.User;
 import co.com.bancolombia.model.session.Session;
@@ -22,18 +23,18 @@ public class SignInUseCase {
     public Mono<Session> execute(User user, ContextData context) {
         log.debug("Iniciando SignIn para email={}, context={}", user != null ? user.getEmail() : null, context);
         if (user == null || user.getEmail() == null || user.getPassword() == null) {
-            log.warn("Request mal formado: {}", user);
+            log.warn("Request mal formado: {}", user.getEmail());
             return Mono.error(new DomainError("MALFORMED_REQUEST", "Request inválido", null, context));
         }
         return userRepository.findByEmail(user.getEmail())
                 .switchIfEmpty(Mono.defer(() -> {
                     log.warn("Usuario no encontrado: {}", user.getEmail());
-                    return Mono.error(new DomainError("USER_NOT_FOUND", "Usuario no existe", null, context));
+                    return Mono.error(new DomainError(CodeMessage.USER_NOT_FOUND_CODE,CodeMessage.USER_NOT_EXISTS_MESSAGE, null, context));
                 }))
                 .flatMap(u -> {
                     if (!u.getPassword().equals(user.getPassword())) {
                         log.warn("Credenciales inválidas para email={}", user.getEmail());
-                        return Mono.error(new DomainError("INVALID_CREDENTIALS", "Credenciales inválidas", null, context));
+                        return Mono.error(new DomainError(CodeMessage.INVALID_CREDENTIALS_CODE, CodeMessage.INVALID_CREDENTIALS_MESSAGE, null, context));
                     }
                     String sessionId = UUID.randomUUID().toString();
                     Session session = new Session(sessionId, user.getEmail());

--- a/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signup/SignUpUseCase.java
+++ b/ms-auth-java/domain/usecase/src/main/java/co/com/bancolombia/usecase/signup/SignUpUseCase.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.usecase.signup;
 
+import co.com.bancolombia.model.exception.model.CodeMessage;
 import co.com.bancolombia.model.signup.gateways.SignUpRepository;
 import co.com.bancolombia.model.user.User;
 import co.com.bancolombia.model.contextdata.ContextData;
@@ -22,21 +23,21 @@ public class SignUpUseCase {
     public Mono<Object> execute(User user, ContextData context) {
         log.debug("Ejecutando signup con datos: user={}, context={}", user, context);
         if (user == null || user.getEmail() == null || user.getPassword() == null) {
-            log.warn("Request inválido: user={}, context={}", user, context);
-            return Mono.error(new DomainError("MALFORMED_REQUEST", "Request inválido", null, context));
+            log.warn("Request inválido: user={}, context={}", user.getEmail(), context);
+            return Mono.error(new DomainError(CodeMessage.MALFORMED_REQUEST_CODE,CodeMessage.REQUEST_INVALID_MESSAGE, null, context));
         }
         if (!EMAIL_REGEX.matcher(user.getEmail()).matches()) {
             log.warn("Email inválido: {}", user.getEmail());
-            return Mono.error(new DomainError("INVALID_EMAIL_FORMAT", "Email inválido", null, context));
+            return Mono.error(new DomainError(CodeMessage.INVALID_EMAIL_FORMAT_CODE, CodeMessage.INVALID_EMAIL_FORMAT_MESSAGE, null, context));
         }
         if (user.getPassword().length() < 8) {
             log.warn("Password débil para email: {}", user.getEmail());
-            return Mono.error(new DomainError("WEAK_PASSWORD", "Password débil", null, context));
+            return Mono.error(new DomainError(CodeMessage.WEAK_PASSWORD_CODE, CodeMessage.WEAK_PASSWORD_MESSAGE, null, context));
         }
         return userRepository.findByEmail(user.getEmail())
                 .flatMap(existing -> {
                     log.warn("Email ya registrado: {}", user.getEmail());
-                    return Mono.error(new DomainError("EMAIL_ALREADY_EXISTS", "Email ya registrado", null, context));
+                    return Mono.error(new DomainError(CodeMessage.EMAIL_ALREADY_EXISTS_CODE, CodeMessage.EMAIL_ALREADY_EXISTS_MESSAGE, null, context));
                 })
                 .switchIfEmpty(Mono.defer(() ->
                         sinUpRepository.save(user)


### PR DESCRIPTION
This pull request refactors error handling in the authentication domain by centralizing error codes and messages in the `CodeMessage` class. The changes improve maintainability and consistency by replacing hardcoded strings in the `SignInUseCase` and `SignUpUseCase` classes with constants from `CodeMessage`.

**Centralization and Consistency of Error Codes and Messages:**

* Replaced all hardcoded error codes and messages in `SignInUseCase` and `SignUpUseCase` with constants from `CodeMessage`, ensuring consistent error handling throughout the authentication logic. [[1]](diffhunk://#diff-0401f5a52cd35d101fe7f2876440de529196137ff25e8964d8abc3a0c243cc24L25-R37) [[2]](diffhunk://#diff-35cafae657e778770680322b85bb69810b06b4d837b196d5e73dc0a783aa7376L25-R40)

**Codebase Simplification:**

* Removed a large set of unused or legacy error message constants from `CodeMessage`, and introduced a focused set of new constants relevant to authentication (e.g., malformed request, user not found, invalid credentials, email format, weak password, email already exists).

**Dependency Updates:**

* Added imports for the new `CodeMessage` constants in both `SignInUseCase` and `SignUpUseCase` classes. [[1]](diffhunk://#diff-0401f5a52cd35d101fe7f2876440de529196137ff25e8964d8abc3a0c243cc24R3) [[2]](diffhunk://#diff-35cafae657e778770680322b85bb69810b06b4d837b196d5e73dc0a783aa7376R3)